### PR TITLE
同一名称の市区町村(東京都府中市と広島県府中市など)が正しく処理されない不具合の修正

### DIFF
--- a/split_geojson.rb
+++ b/split_geojson.rb
@@ -16,10 +16,10 @@ class GeoJsonToCity
         # 都道府県
         self.setData(city[0], feature)
         # 市町村1
-        self.setData(city[1], feature)
+        self.setData(city[0] + city[1], feature)
         # 市町村2
         if !city[2].nil?
-          word = city[1] + city[2]
+          word = city[0] + city[1] + city[2]
           self.setData(word, feature)
         end
       end
@@ -61,7 +61,7 @@ class GeoJsonToCity
       addr = self.checkCity(collection[0]['properties'])
       pref = addr[0]
       FileUtils.mkdir_p('geojson/' + pref)
-      File.open('geojson/' + pref + '/' + city + '.json', 'w').write(JSON.generate(data))
+      File.open('geojson/' + pref + '/' + ( ( city == pref ) ? city : city.sub( /^#{pref}/, '' ) ) + '.json', 'w').write(JSON.generate(data))
     end
   end
 


### PR DESCRIPTION
はじめまして。  
異なる都道府県下に同じ市区町村名がある場合、split_geojson.rb で正しく分割されないようです。  

例） 「東京都府中市」と「広島県府中市」だと、  
- 東京都/府中市.json  
- 広島県/府中市.json  

が生成されるべきですが、後者は生成されず、後者のデータが前者に含まれてしまいます。  
これに関する修正を行いましたので、ご確認の上、merge いただけると幸いです。
よろしくお願いします。
